### PR TITLE
Detach accordion from card without requiring 'data-children'

### DIFF
--- a/js/src/collapse.js
+++ b/js/src/collapse.js
@@ -56,9 +56,8 @@ const Collapse = (($) => {
   }
 
   const Selector = {
-    ACTIVES     : '.card > .show, .card > .collapsing',
-    DATA_TOGGLE : '[data-toggle="collapse"]',
-    DATA_CHILDREN : 'data-children'
+    ACTIVES     : '.show, .collapsing',
+    DATA_TOGGLE : '[data-toggle="collapse"]'
   }
 
 
@@ -78,18 +77,11 @@ const Collapse = (($) => {
         `[data-toggle="collapse"][href="#${element.id}"],` +
         `[data-toggle="collapse"][data-target="#${element.id}"]`
       ))
+
       this._parent = this._config.parent ? this._getParent() : null
 
       if (!this._config.parent) {
         this._addAriaAndCollapsedClass(this._element, this._triggerArray)
-      }
-
-      this._selectorActives = Selector.ACTIVES
-      if (this._parent) {
-        const childrenSelector = this._parent.hasAttribute(Selector.DATA_CHILDREN) ? this._parent.getAttribute(Selector.DATA_CHILDREN) : null
-        if (childrenSelector !== null) {
-          this._selectorActives = `${childrenSelector} > .show, ${childrenSelector} > .collapsing`
-        }
       }
 
       if (this._config.toggle) {
@@ -129,7 +121,7 @@ const Collapse = (($) => {
       let activesData
 
       if (this._parent) {
-        actives = $.makeArray($(this._parent).find(this._selectorActives))
+        actives = $.makeArray($(this._parent).children().children(Selector.ACTIVES))
         if (!actives.length) {
           actives = null
         }


### PR DESCRIPTION
Update upstream