### PR TITLE
Fix typo removeData for Tabs plugin

### DIFF
--- a/js/src/tab.js
+++ b/js/src/tab.js
@@ -140,7 +140,7 @@ const Tab = (($) => {
     }
 
     dispose() {
-      $.removeClass(this._element, DATA_KEY)
+      $.removeData(this._element, DATA_KEY)
       this._element = null
     }
 


### PR DESCRIPTION
Should remove `data` not `class` on dispose