### PR TITLE
Link to package.json Fixed

### DIFF
--- a/docs/getting-started/build-tools.md
+++ b/docs/getting-started/build-tools.md
@@ -5,7 +5,7 @@ description: Details on how to use Bootstrap's included build tools to compile s
 group: getting-started
 ---
 
-Bootstrap uses [NPM scripts](https://docs.npmjs.com/misc/scripts) for its build system. Our [package.json](https://github.com/twbs/bootstrap/blob/master/package.json) includes convenient methods for working with the framework, including compiling code, running tests, and more.
+Bootstrap uses [NPM scripts](https://docs.npmjs.com/misc/scripts) for its build system. Our [package.json](https://github.com/twbs/bootstrap/blob/v4-dev/package.json) includes convenient methods for working with the framework, including compiling code, running tests, and more.
 
 ## Contents
 


### PR DESCRIPTION
The link to package.json in the v4 docs was linking to package.json in the v3 source.  Fixed to point to the correct v4 location.  A change like this will need to be made for all branches on version 4 if you want the docs to be linked correctly (github may be smart enough to follow the link to the current branch if you are on github but it was wrong from the main site).