### PR TITLE
Remove Firefox transitioncancel entry from Most Wanted list

### DIFF
--- a/_data/browser-features.yml
+++ b/_data/browser-features.yml
@@ -62,16 +62,6 @@
   browser: >
     Firefox
   summary: >
-    Fire a [`transitioncancel` event](https://developer.mozilla.org/en-US/docs/Web/Events/transitioncancel) when a CSS transition is canceled
-  upstream_bug: >
-    Mozilla#1264125
-  origin: >
-    Mozilla#1182856
-
--
-  browser: >
-    Firefox
-  summary: >
     Implement the [`of <selector-list>` clause](http://caniuse.com/#feat=css-nth-child-of) of the `:nth-child()` pseudo-class
   upstream_bug: >
     Mozilla#854148


### PR DESCRIPTION
The transitioncancel event was shipped in Firefox 53 🎉
https://bugzilla.mozilla.org/show_bug.cgi?id=1264125