### PR TITLE
add a modifier for pure functions

### DIFF
--- a/site/docs/4.1/examples/floating-labels/floating-labels.css
+++ b/site/docs/4.1/examples/floating-labels/floating-labels.css
@@ -40,6 +40,7 @@ body {
   margin-bottom: 0; /* Override default `<label>` margin */
   line-height: 1.5;
   color: #495057;
+  pointer-events: none;
   cursor: text; /* Match the input under the label */
   border: 1px solid transparent;
   border-radius: .25rem;


### PR DESCRIPTION
* prevent text selection for floating labels
  * expand the click target by no selecting the label text
* use `pointer-events: none;` instead of `user-select`
  * thx @MartijnCuppens